### PR TITLE
Configure proxy backend

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -1,0 +1,8 @@
+location /pro {
+  proxy_pass <%= ENV["URL_ESPACE_PRO"] %>;
+  proxy_redirect https://$proxy_host https://$host;
+}
+
+location / {
+  proxy_pass <%= ENV["URL_SITE_VITRINE"] %>;
+}


### PR DESCRIPTION
Permet d'utiliser une adresse de type eva.beta.gouv.fr/pro pour l'espace pro.