### PR TITLE
Configure un host différent dans les headers

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -1,6 +1,7 @@
 location /pro {
   proxy_pass <%= ENV["URL_ESPACE_PRO"] %>;
   proxy_redirect https://$proxy_host https://$host;
+  proxy_set_header Host $host;
 }
 
 location /competences {


### PR DESCRIPTION
Car Rails recoit un host du style "https://eva-serveur-preprod.osc-fr1.scalingo.io" et
selon ma compréhension des choses, rails l'utilise pour construire une url absolue qui n'utilise donc pas le bon nom de domaine