### PR TITLE
Définis le fichier .buildpacks pour définir le(s) buildpacks à utiliser

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,1 @@
+https://github.com/Scalingo/nginx-buildpack.git


### PR DESCRIPTION
Cela permet :
- d'utiliser plusieurs buildpacks à la fois
- de définir le buildpack à utiliser au niveau du code et réduire la gestion des variables d'environnements

plus d'informations ici : https://doc.scalingo.com/platform/deployment/buildpacks/multi

On pourra donc retirer la variable d'env : `BUILDPACK_URL`