### PR TITLE
indique aussi le port vers lequel est redirigé /

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -4,10 +4,6 @@ location /pro {
   proxy_set_header X-Forwarded-Host $host;
 }
 
-location /competences {
-  rewrite ^/competences/(.*)$ https://$host/$1 redirect;
-}
-
 location / {
   proxy_pass <%= ENV["URL_SITE_VITRINE"] %>;
   proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
En ajoutant le port dans la variable d'environnement URL_SITE_VITRINE, on règle les problèmes de page non joignable dans wordpress.

par exemple, l'url 
https://eva.beta.gouv.fr/statistiques
sera bien redirigée vers 
https://eva.beta.gouv.fr/statistiques/

De même 

https://eva.beta.gouv.fr/competences/rapidite
sera bien redirigée vers 
https://eva.beta.gouv.fr/rapidite/

Ce qui rends inutile la redirection par nginx.
