### PR TITLE
On remet la redirection pour gérer les anciennes urls des métiers

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -10,6 +10,10 @@ location /jeu {
   proxy_set_header X-Forwarded-Host $host;
 }
 
+location /competences {
+  rewrite ^/competences/(.*)$ https://$host/$1 redirect;
+}
+
 location / {
   proxy_pass <%= ENV["URL_SITE_VITRINE"] %>;
   proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
Puisque wordpress à décidé de ne plus s'en occuper !