### PR TITLE
Configure comme un proxyPassReverse

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -15,6 +15,9 @@ location /competences {
 }
 
 location / {
+  proxy_set_header X-Forwarded-Host $host:$server_port;
+  proxy_set_header X-Forwarded-Server $host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_pass <%= ENV["URL_SITE_VITRINE"] %>;
-  proxy_set_header X-Forwarded-Host $host;
+  proxy_redirect https://$proxy_host https://$host;
 }


### PR DESCRIPTION
Dans le but d'essayer de corriger nos problèmes d'indisponibilité du site vitrine, je propose d'essayer cette configuration.

Je me suis inspiré de ces deux documentations :
https://httpd.apache.org/docs/2.4/fr/howto/reverse_proxy.html
https://www.nginx.com/resources/wiki/start/topics/examples/likeapache/

J'ai déployé cette branche en prod (sur eva-proxy). Ça continue de marcher. reste à voir si les problèmes d'indisponibilité auront disparus
