### PR TITLE
Retourne une 403 quand on tente d'accéder à /xmlrc.php

### DIFF
--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -14,6 +14,12 @@ location /competences {
   rewrite ^/competences/(.*)$ https://$host/$1 redirect;
 }
 
+location /xmlrpc.php {
+  deny all;
+  access_log off;
+  log_not_found off;
+}
+
 location / {
   proxy_set_header X-Forwarded-Host $host:$server_port;
   proxy_set_header X-Forwarded-Server $host;


### PR DESCRIPTION
Aujourd'hui, l'hébergeur du wordpress (alwaysdata) recoit beaucoup de demande pour accéder à ce fichier
et considère cela comme du spam.

Selon le blog : https://kinsta.com/fr/blog/xmlrpc-php/

Ce fichier n'est plus très utile pour les versions récentes de WP et notre cas d'usage.

J'ai donc bloqué l'accès à cette url. (Je me suis inspiré de ca : https://computingforgeeks.com/how-to-disable-xmlrpc-php-access-in-wordpress/)